### PR TITLE
Allow skipping $hook callbacks if $hook is empty

### DIFF
--- a/src/Formatter/Hook_Formatter.php
+++ b/src/Formatter/Hook_Formatter.php
@@ -37,16 +37,18 @@ class Hook_Formatter {
 		}
 		ksort( $hook );
 
-		$functions = array_merge( ...$hook );
+		if ( $hook ) {
+			$functions = array_merge( ...$hook );
 
-		foreach ( $functions as $function ) {
-			$callback = $this->get_callback_name( $function['function'], $function['accepted_args'] );
+			foreach ( $functions as $function ) {
+				$callback = $this->get_callback_name( $function['function'], $function['accepted_args'] );
 
-			if ( false !== strpos( $callback, 'Hook_Collector' ) ) {
-				continue;
+				if ( false !== strpos( $callback, 'Hook_Collector' ) ) {
+					continue;
+				}
+
+				$callbacks[] = $callback;
 			}
-
-			$callbacks[] = $callback;
 		}
 
 		return $callbacks;


### PR DESCRIPTION
The events system seems to be in conflict with Illuminate in some way (using Roots stack).

$hook ends up being empty which causes total failure on the array_merge(). Traces back to Illuminate's Container.

This is just a quick patch that has allowed me to continue to explore using this excellent plugin; I'm not sure what would be required to more fully correct for this issue. 

Thank you for your contributions to PHP and WP!