### PR TITLE
check WP root directory for composer path

### DIFF
--- a/laps.php
+++ b/laps.php
@@ -14,6 +14,8 @@ License: MIT
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
+} elseif ( file_exists( ABSPATH . '/vendor/autoload.php' ) ) {
+	require ABSPATH . '/vendor/autoload.php';
 }
 
 if ( ! class_exists( '\Rarst\Laps\Plugin' ) ) {


### PR DESCRIPTION
This allows the plugin to be activated if:

1. It was installed using composer in the root of the WP site.
2. The autoloader has not been included when the plugin is loaded.